### PR TITLE
Flag Enjin Farmer sample game pages as Platform v2

### DIFF
--- a/docs/02-guides/01-platform/05-enjin-farmer-sample-game/01-setup-guide.md
+++ b/docs/02-guides/01-platform/05-enjin-farmer-sample-game/01-setup-guide.md
@@ -7,6 +7,10 @@ description: "Follow our step-by-step guide to set up a sample Unity game with f
 
 import GlossaryTerm from '@site/src/components/GlossaryTerm';
 
+:::warning Built for Enjin Platform v2
+This guide and its sample code still target **Enjin Platform v2**. The rest of these docs have moved to **Enjin Platform v3** (currently in beta) — this page will be updated for v3 soon.
+:::
+
 Welcome! This guide will walk you through setting up and running the Enjin Farm Game, a sample project demonstrating how to integrate Enjin's NFT technology into a Unity game.
 
 In this simple farming game, you'll plant seeds, harvest crops, and collect resources. Some resources are special and will be minted as NFTs directly to your in-game wallet. You can then view these NFTs in your inventory, <GlossaryTerm id="melt" /> them, or transfer them to an external wallet.

--- a/docs/02-guides/01-platform/05-enjin-farmer-sample-game/03-implementation-breakdown.md
+++ b/docs/02-guides/01-platform/05-enjin-farmer-sample-game/03-implementation-breakdown.md
@@ -7,6 +7,10 @@ description: "Dive deep into the code and architecture of the Enjin Farmer sampl
 
 import GlossaryTerm from '@site/src/components/GlossaryTerm';
 
+:::warning Built for Enjin Platform v2
+This breakdown and its sample code still target **Enjin Platform v2**. The rest of these docs have moved to **Enjin Platform v3** (currently in beta) — this page will be updated for v3 soon.
+:::
+
 The **Enjin Farmer** sample project demonstrates a basic Enjin Platform integration within a Unity game. It's built with a client-server architecture to ensure security and scalability.
 
 The project consists of two main components:


### PR DESCRIPTION
Add a callout to both Farmer sample game pages noting they still target Enjin Platform v2 while the rest of the docs have moved to v3, and that they'll be updated for v3 soon.